### PR TITLE
ADD: NCP Geo Service 연동

### DIFF
--- a/src/main/java/com/restspotfinder/geo/domain/GeoPoint.java
+++ b/src/main/java/com/restspotfinder/geo/domain/GeoPoint.java
@@ -1,0 +1,38 @@
+package com.restspotfinder.geo.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.LineString;
+
+import java.util.List;
+
+@Getter
+@Builder
+@ToString
+@AllArgsConstructor
+public class GeoPoint {
+    private String xValue; // 경도
+    private String yValue; // 위도
+
+    public static GeoPoint from(String xValue, String yValue){
+        return GeoPoint.builder()
+                .xValue(xValue)
+                .yValue(yValue)
+                .build();
+    }
+
+    public static LineString convertToLineString(List<GeoPoint> geoPointList){
+        GeometryFactory geometryFactory = new GeometryFactory();
+        Coordinate[] coordinates = geoPointList.stream()
+                .map(geoPoint -> new Coordinate(
+                        Double.parseDouble(geoPoint.getXValue()), // 경도
+                        Double.parseDouble(geoPoint.getYValue())  // 위도
+                ))
+                .toArray(Coordinate[]::new);
+        return geometryFactory.createLineString(coordinates);
+    }
+}

--- a/src/main/java/com/restspotfinder/geo/service/GeoService.java
+++ b/src/main/java/com/restspotfinder/geo/service/GeoService.java
@@ -1,0 +1,86 @@
+package com.restspotfinder.geo.service;
+
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.restspotfinder.geo.domain.GeoPoint;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+
+@Component
+@RequiredArgsConstructor
+public class GeoService {
+    @Value("${ncp.geo.url}")
+    String POINT_URL;
+    @Value("${ncp.geo.direct5-url}")
+    String ROUTE_URL;
+    @Value("${ncp.geo.client-id}")
+    String CLIENT_ID;
+    @Value("${ncp.geo.client-secret}")
+    String CLIENT_SECRET;
+
+    public GeoPoint getGeoPoint(String address) {
+        String requestURL = POINT_URL + "?query=" + address;
+
+        JsonNode jsonNode = connect(requestURL);
+        JsonNode addressesNode = jsonNode.get("addresses").get(0);
+        System.out.println("roadAddress = " + getDirectTextFromJsonNode(addressesNode, "roadAddress"));
+        System.out.println("jibunAddress = " + getDirectTextFromJsonNode(addressesNode, "jibunAddress"));
+
+        return GeoPoint.from(
+                getDirectTextFromJsonNode(addressesNode, "x"),
+                getDirectTextFromJsonNode(addressesNode, "y"));
+    }
+
+    public List<GeoPoint> getRouteData(String start, String goal) {
+        String requestURL = ROUTE_URL + "?start=" + start + "&goal=" + goal + "&option=trafast";
+
+        JsonNode jsonNode = connect(requestURL);
+        ArrayNode pathArray = (ArrayNode) jsonNode.get("route").get("trafast").get(0).get("path");
+        List<GeoPoint> route = new ArrayList<>();
+        for (JsonNode path : pathArray) {
+            String x = path.get(0).asText();
+            String y = path.get(1).asText();
+            route.add(GeoPoint.from(x, y));
+        }
+
+        return route;
+    }
+
+    public JsonNode connect(String requestURL) {
+        try {
+            HttpComponentsClientHttpRequestFactory httpRequestFactory = new HttpComponentsClientHttpRequestFactory();
+            RestTemplate restTemplate = new RestTemplate(httpRequestFactory);
+            HttpHeaders headers = new HttpHeaders();
+            headers.set("X-NCP-APIGW-API-KEY-ID", CLIENT_ID);
+            headers.set("X-NCP-APIGW-API-KEY", CLIENT_SECRET);
+
+            HttpEntity<Object> entity = new HttpEntity<>(headers);
+            ResponseEntity<String> responseEntity = restTemplate.exchange(requestURL, HttpMethod.GET, entity, String.class);
+
+            return new ObjectMapper().readTree(responseEntity.getBody());
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new RuntimeException();
+        }
+    }
+
+    private String getDirectTextFromJsonNode(JsonNode jsonNode, String fieldName) {
+        return Optional.ofNullable(jsonNode.get(fieldName))
+                .map(JsonNode::asText)
+                .orElse("");
+    }
+}

--- a/src/test/java/com/restspotfinder/geo/GeoServiceTest.java
+++ b/src/test/java/com/restspotfinder/geo/GeoServiceTest.java
@@ -1,0 +1,55 @@
+package com.restspotfinder.geo;
+
+import com.restspotfinder.geo.domain.GeoPoint;
+import com.restspotfinder.geo.service.GeoService;
+import com.restspotfinder.route.domain.TempRoute;
+import com.restspotfinder.route.repository.TempRouteRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.locationtech.jts.geom.Point;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.List;
+
+@SpringBootTest
+@ExtendWith(SpringExtension.class)
+class GeoServiceTest {
+    @Autowired
+    GeoService geoService;
+    @Autowired
+    TempRouteRepository tempRouteRepository;
+
+    @Test
+    void getGeoPoint() {
+        // given
+        String address = "충북 옥천군 옥천읍 중앙로 99";
+
+        // when
+        GeoPoint geoPoint = geoService.getGeoPoint(address);
+
+        // then
+        System.out.println("GeoPoint = " +  geoPoint);
+    }
+
+    @Test
+    void getRouteData() {
+        // given
+        String goal = "127.1285607,37.4319958"; // 모란 오라타워
+        String start = "127.1468225,36.8123208"; // 천안역
+//        String start = "129.0449881,35.1177214"; // 부산역
+//        String start = "127.4321036,36.3344179"; // 대전역
+//        String start = "127.5714191,36.3064369"; // 옥천구청
+//        String start = "127.8280515,36.2640232"; // 구룡초등학교
+//        String goal = "127.9112630,36.2245680"; // 황간역
+
+        // when
+        List<GeoPoint>  pointList = geoService.getRouteData(start, goal);
+
+        // then
+        for(GeoPoint p : pointList){
+            System.out.println("p = " + p);
+        }
+    }
+}


### PR DESCRIPTION
## 💡 개요
Naver Cloud Platform Geo Service와 연동했어요

## 📃 작업내용
1. 주소로 위도, 경도 데이터를 가져오기 위해 NCP의 GeoService와 연동했어요.
2. 출발지와 도착지 사이의 경로를 가져올 수 있는 NCP Route5 Service와 연동했어요.