### PR TITLE
ADD: /api/route API 추가

### DIFF
--- a/src/main/java/com/restspotfinder/route/controller/TempRouteController.java
+++ b/src/main/java/com/restspotfinder/route/controller/TempRouteController.java
@@ -1,0 +1,39 @@
+package com.restspotfinder.route.controller;
+
+import com.restspotfinder.route.domain.OptionCode;
+import com.restspotfinder.route.domain.TempRoute;
+import com.restspotfinder.route.response.TempRouteResponse;
+import com.restspotfinder.route.service.NCPGeoService;
+import com.restspotfinder.route.service.TempPointService;
+import com.restspotfinder.route.service.TempRouteService;
+import lombok.RequiredArgsConstructor;
+import org.locationtech.jts.geom.Coordinate;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/route")
+public class TempRouteController {
+    private final NCPGeoService ncpGeoService;
+    private final TempRouteService tempRouteService;
+    private final TempPointService tempPointService;
+
+    @GetMapping
+    public ResponseEntity getRoute(@RequestParam String start, @RequestParam String goal) {
+        Map<OptionCode, Coordinate[]> coordinateMap = ncpGeoService.getRouteData(start, goal);
+        List<TempRouteResponse> responseList = coordinateMap.entrySet().stream().map(entry -> {
+            TempRoute savedTempRoute = tempRouteService.create(entry.getValue(), entry.getKey()); // 경로 저장
+            tempPointService.create(entry.getValue(), savedTempRoute.getRouteId()); // 휴게소와 좌표 비교할 Point List 저장
+            return TempRouteResponse.from(savedTempRoute);
+        }).toList();
+
+        return ResponseEntity.ok().body(responseList);
+    }
+}

--- a/src/main/java/com/restspotfinder/route/domain/OptionCode.java
+++ b/src/main/java/com/restspotfinder/route/domain/OptionCode.java
@@ -1,0 +1,27 @@
+package com.restspotfinder.route.domain;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import lombok.Getter;
+
+@Getter
+public enum OptionCode {
+    fast("trafast", "실시간 빠른길"),
+    optimal("traoptimal", "실시간 최적"),
+    avoidtoll("traavoidtoll", "무료 우선"),
+    comfort("tracomfort", "실시간 편한길"),
+    avoidcaronly("traavoidcaronly", "자동차 전용 도로 회피 우선");
+
+    private final String value;
+    private final String desc;
+
+    OptionCode(String value, String desc) {
+        this.value = value;
+        this.desc = desc;
+    }
+
+    // @RequestParam ENUM Parsing
+    @JsonCreator
+    public static OptionCode from(String s) {
+        return OptionCode.valueOf(s);
+    }
+}

--- a/src/main/java/com/restspotfinder/route/domain/TempRoute.java
+++ b/src/main/java/com/restspotfinder/route/domain/TempRoute.java
@@ -20,11 +20,14 @@ public class TempRoute {
     private Long routeId;
     @Column(columnDefinition = "geometry(LineString, 4326)")
     private LineString lineString;
+    @Enumerated(EnumType.STRING)
+    private OptionCode optionCode;
     private LocalDateTime createdDate;
 
-    public static TempRoute from(GeometryFactory geometryFactory, Coordinate[] coordinates) {
+    public static TempRoute from(GeometryFactory geometryFactory, Coordinate[] coordinates, OptionCode optionCode) {
         return TempRoute.builder()
                 .lineString(geometryFactory.createLineString(coordinates))
+                .optionCode(optionCode)
                 .createdDate(LocalDateTime.now())
                 .build();
     }

--- a/src/main/java/com/restspotfinder/route/response/TempRouteResponse.java
+++ b/src/main/java/com/restspotfinder/route/response/TempRouteResponse.java
@@ -1,0 +1,28 @@
+package com.restspotfinder.route.response;
+
+import com.restspotfinder.route.domain.OptionCode;
+import com.restspotfinder.route.domain.TempRoute;
+import lombok.Builder;
+import lombok.Getter;
+import org.locationtech.jts.geom.Coordinate;
+
+import java.time.LocalDateTime;
+
+
+@Getter
+@Builder
+public class TempRouteResponse {
+    private Long routeId;
+    private Coordinate[] coordinateList;
+    private OptionCode optionCode;
+    private LocalDateTime createdDate;
+
+    public static TempRouteResponse from(TempRoute tempRoute) {
+        return TempRouteResponse.builder()
+                .routeId(tempRoute.getRouteId())
+                .coordinateList(tempRoute.getLineString().getCoordinates())
+                .optionCode(tempRoute.getOptionCode())
+                .createdDate(tempRoute.getCreatedDate())
+                .build();
+    }
+}

--- a/src/main/java/com/restspotfinder/route/service/TempPointService.java
+++ b/src/main/java/com/restspotfinder/route/service/TempPointService.java
@@ -1,0 +1,23 @@
+package com.restspotfinder.route.service;
+
+import com.restspotfinder.route.domain.TempPoint;
+import com.restspotfinder.route.repository.TempPointRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class TempPointService {
+    private final TempPointRepository tempRouteRepository;
+    private final GeometryFactory geometryFactory = new GeometryFactory();
+
+    @Transactional
+    public List<TempPoint> create(Coordinate[] coordinates, long routeId) {
+        return tempRouteRepository.saveAll(TempPoint.fromList(geometryFactory, coordinates, routeId));
+    }
+}

--- a/src/main/java/com/restspotfinder/route/service/TempRouteService.java
+++ b/src/main/java/com/restspotfinder/route/service/TempRouteService.java
@@ -1,0 +1,22 @@
+package com.restspotfinder.route.service;
+
+import com.restspotfinder.route.domain.OptionCode;
+import com.restspotfinder.route.domain.TempRoute;
+import com.restspotfinder.route.repository.TempRouteRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TempRouteService {
+    private final TempRouteRepository tempRouteRepository;
+    private final GeometryFactory geometryFactory = new GeometryFactory();
+
+    @Transactional
+    public TempRoute create(Coordinate[] coordinates, OptionCode optionCode) {
+        return tempRouteRepository.save(TempRoute.from(geometryFactory, coordinates, optionCode));
+    }
+}

--- a/src/test/java/com/restspotfinder/route/service/NCPGeoServiceTest.java
+++ b/src/test/java/com/restspotfinder/route/service/NCPGeoServiceTest.java
@@ -1,5 +1,7 @@
 package com.restspotfinder.route.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.restspotfinder.route.domain.OptionCode;
 import com.restspotfinder.route.domain.TempPoint;
 import com.restspotfinder.route.domain.TempRoute;
 import com.restspotfinder.route.repository.TempPointRepository;
@@ -13,6 +15,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.util.List;
+import java.util.Map;
 
 
 @SpringBootTest
@@ -29,7 +32,7 @@ class NCPGeoServiceTest {
     @Test
     void getCoordinate() {
         // given
-        String address = "충북 옥천군 옥천읍 중앙로 99";
+        String address = "강원 정선군 고한읍 하이원길 424";
 
         // when
         Coordinate coordinate = NCPGeoService.getCoordinate(address);
@@ -39,26 +42,32 @@ class NCPGeoServiceTest {
     }
 
     @Test
-    void getRouteData() {
+    void getRouteData() throws JsonProcessingException {
         // given
-        String goal = "127.1285607,37.4319958"; // 모란 오라타워
-        String start = "127.1468225,36.8123208"; // 천안역
+        String start = "127.1285607,37.4319958"; // 모란 오라타워
+//        String start = "127.1468225,36.8123208"; // 천안역
 //        String start = "129.0449881,35.1177214"; // 부산역
 //        String start = "127.4321036,36.3344179"; // 대전역
 //        String start = "127.5714191,36.3064369"; // 옥천구청
 //        String start = "127.8280515,36.2640232"; // 구룡초등학교
 //        String goal = "127.9112630,36.2245680"; // 황간역
+        String goal = "128.8376985, 37.2066719"; // 하이원 리조트
 
         // when
-        Coordinate[] coordinates = NCPGeoService.getRouteData(start, goal);
+        Map<OptionCode, Coordinate[]> coordinateMap = NCPGeoService.getRouteData(start, goal);
 
         // then
         GeometryFactory geometryFactory = new GeometryFactory();
+        for (Map.Entry<OptionCode, Coordinate[]> entry : coordinateMap.entrySet()) {
+            OptionCode optionCode = entry.getKey(); // 키 (OptionCode) 얻기
+            Coordinate[] coordinates = entry.getValue(); // 값 (Coordinate 배열) 얻기
 
-        TempRoute tempRoute = TempRoute.from(geometryFactory, coordinates);
-        TempRoute savedTempRoute = tempRouteRepository.save(tempRoute);
+            System.out.println("Option: " + optionCode);
+            TempRoute tempRoute = TempRoute.from(geometryFactory, coordinates, optionCode);
+            TempRoute savedTempRoute = tempRouteRepository.save(tempRoute);
 
-        List<TempPoint> tempPointList = TempPoint.fromList(geometryFactory, coordinates, savedTempRoute.getRouteId());
-        tempPointRepository.saveAll(tempPointList);
+            List<TempPoint> tempPointList = TempPoint.fromList(geometryFactory, coordinates, savedTempRoute.getRouteId());
+            tempPointRepository.saveAll(tempPointList);
+        }
     }
 }


### PR DESCRIPTION
## 💡 개요
/api/route API 추가

## 📃 작업내용
1. 출발지 좌표, 도착지 좌표를 입력받고
2. 둘 사이의 경로를 NCP API를 통해 조회하고
3. 해당 데이터를 DB에 저장한 후 
4. Response 객체로 컨버팅해 반환하는
API를 추가했어요.

## 🔀 변경사항
- Ncp Direct 5 Service의 경로 옵션 필드를 위한 OptionCode(Enum)을 생성.
- TempRoute Domain에 OptionCode 추가
